### PR TITLE
Provide temporary kube token

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This action logs in to Rancher and generate a token which can be used to access 
 
 ### `kubeconfig_base64`: The base64 kubeconfig content.
 
+### `temporary_kube_token`: A temporary token that you can use to run kubectl which will be expired (usually after 24 hours).
+
 
 ## Example usage
 
@@ -82,6 +84,18 @@ jobs:
         run: |
           kubectl get namespace \
             --token=${{ steps.generate-rancher-auth.outputs.kube_token }} \
+            --server=${{ steps.generate-rancher-auth.outputs.kubeapi_server_ace }} 
+
+      - name: Check namespace in the cluster with temporary token and default rancher server
+        run: |
+          kubectl get namespace \
+            --token=${{ steps.generate-rancher-auth.outputs.temporary_kube_token }} \
+            --server=${{ steps.generate-rancher-auth.outputs.kubeapi_server }}
+
+      - name: Check namespace in the cluster with temporary token and Authorized Cluster Endpoints server
+        run: |
+          kubectl get namespace \
+            --token=${{ steps.generate-rancher-auth.outputs.temporary_kube_token }} \
             --server=${{ steps.generate-rancher-auth.outputs.kubeapi_server_ace }} 
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ jobs:
         run: |
           kubectl get namespace \
             --token=${{ steps.generate-rancher-auth.outputs.kube_token }} \
-            --server=${{ steps.generate-rancher-auth.outputs.kubeapi_server_ace }} 
+            --server=${{ steps.generate-rancher-auth.outputs.kubeapi_server_ace }}
 
       - name: Check namespace in the cluster with temporary token and default rancher server
         run: |
@@ -92,20 +92,26 @@ jobs:
             --token=${{ steps.generate-rancher-auth.outputs.temporary_kube_token }} \
             --server=${{ steps.generate-rancher-auth.outputs.kubeapi_server }}
 
-      - name: Check namespace in the cluster with temporary token and Authorized Cluster Endpoints server
+      - name: List Helm releases in the cluster with temporary token and default rancher server
         run: |
-          kubectl get namespace \
-            --token=${{ steps.generate-rancher-auth.outputs.temporary_kube_token }} \
-            --server=${{ steps.generate-rancher-auth.outputs.kubeapi_server_ace }} 
+          helm list \
+            --kube-token=${{ steps.generate-rancher-auth.outputs.temporary_kube_token }} \
+            --kube-apiserver=${{ steps.generate-rancher-auth.outputs.kubeapi_server }}
 ```
 
-Recommand to use token as example below. but kubeconfig is also a possible option.
+We recommand to use token and server as the examples above but using the kubeconfig is also a possible option.
 ```yaml
       - name: Check namespace in the cluster with kubeconfig
         run: |
           echo ${{ steps.generate-rancher-auth.outputs.kubeconfig_base64 }} | base64 -d > kubeconfig
           export KUBECONFIG=./kubeconfig
           kubectl get namespace
+
+      - name: List Helm releases in the cluster with kubeconfig
+        run: |
+          echo ${{ steps.generate-rancher-auth.outputs.kubeconfig_base64 }} | base64 -d > kubeconfig
+          export KUBECONFIG=./kubeconfig
+          helm list
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -91,12 +91,6 @@ jobs:
           kubectl get namespace \
             --token=${{ steps.generate-rancher-auth.outputs.temporary_kube_token }} \
             --server=${{ steps.generate-rancher-auth.outputs.kubeapi_server }}
-
-      - name: List Helm releases in the cluster with temporary token and default rancher server
-        run: |
-          helm list \
-            --kube-token=${{ steps.generate-rancher-auth.outputs.temporary_kube_token }} \
-            --kube-apiserver=${{ steps.generate-rancher-auth.outputs.kubeapi_server }}
 ```
 
 We recommand to use token and server as the examples above but using the kubeconfig is also a possible option.
@@ -106,13 +100,4 @@ We recommand to use token and server as the examples above but using the kubecon
           echo ${{ steps.generate-rancher-auth.outputs.kubeconfig_base64 }} | base64 -d > kubeconfig
           export KUBECONFIG=./kubeconfig
           kubectl get namespace
-
-      - name: List Helm releases in the cluster with kubeconfig
-        run: |
-          echo ${{ steps.generate-rancher-auth.outputs.kubeconfig_base64 }} | base64 -d > kubeconfig
-          export KUBECONFIG=./kubeconfig
-          helm list
 ```
-
-
-

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,9 @@ outputs:
   kubeconfig_base64:
     description: "kubeconfig base64 content"
     value: ${{ steps.get-auth.outputs.kubeconfig_base64 }}
+  temporary_kube_token:
+    description: "temporary kube token"
+    value: ${{ steps.get-auth.outputs.temporary_kube_token }}
 runs:
   using: "composite"
   steps:

--- a/gen_token.sh
+++ b/gen_token.sh
@@ -53,5 +53,5 @@ echo ::add-mask::$TOKEN
 echo ::set-output name=kube_token::$TOKEN
 echo ::set-output name=kubeapi_server::$SERVER_RANCHER
 echo ::set-output name=kubeapi_server_ace::$SERVER_ACE
+echo ::add-mask::$RANCHER_TOKEN
 echo ::set-output name=temporary_kube_token::$RANCHER_TOKEN
-

--- a/gen_token.sh
+++ b/gen_token.sh
@@ -41,10 +41,10 @@ fi
 KUBECONFIG=$(curl --noproxy '*' -s -u $RANCHER_TOKEN https://$RANCHER_SERVER/v3/clusters/$CLUSTER_ID?action=generateKubeconfig -X POST -H 'content-type: application/json' | jq -r .config | base64 -w0)   
 
 # Get access token and api server from kubeconfig
-TOKEN=$(echo $KUBECONFIG | base64 -d | awk '/token:/ {print $2}')
-SERVER=$(echo $KUBECONFIG | base64 -d | awk '/server:/ {print $2}')
-SERVER_RANCHER=$(echo $SERVER | awk '{print $1}')
-SERVER_ACE=$(echo $SERVER | awk '{print $2}')
+TOKEN=$(echo $KUBECONFIG | base64 -d | awk '/token:/ {print $2}' | awk '{gsub(/"/,"")};1')
+SERVER=$(echo $KUBECONFIG | base64 -d | awk '/server:/ {print $2}' | awk '{gsub(/"/,"")};1')
+SERVER_RANCHER=$(echo $SERVER | awk '{print $1}' | awk '{gsub(/"/,"")};1')
+SERVER_ACE=$(echo $SERVER | awk '{print $2}' | awk '{gsub(/"/,"")};1')
 
 # Set output
 echo ::add-mask::$KUBECONFIG

--- a/gen_token.sh
+++ b/gen_token.sh
@@ -53,3 +53,5 @@ echo ::add-mask::$TOKEN
 echo ::set-output name=kube_token::$TOKEN
 echo ::set-output name=kubeapi_server::$SERVER_RANCHER
 echo ::set-output name=kubeapi_server_ace::$SERVER_ACE
+echo ::set-output name=temporary_kube_token::$RANCHER_TOKEN
+


### PR DESCRIPTION
Since we have the situation of getting disabled tokens we need a way to use the generated temporary kube token instead.